### PR TITLE
Proposed-OgreHeaders

### DIFF
--- a/Mezzanine/src/Graphics/billboard.cpp
+++ b/Mezzanine/src/Graphics/billboard.cpp
@@ -49,7 +49,9 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreVector3.h>
+#include <OgreMath.h>
+#include <OgreBillboard.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/billboardsetproxy.cpp
+++ b/Mezzanine/src/Graphics/billboardsetproxy.cpp
@@ -51,7 +51,9 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreBillboardSet.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/bone.cpp
+++ b/Mezzanine/src/Graphics/bone.cpp
@@ -43,7 +43,7 @@
 #include "Graphics/skeleton.h"
 #include "Graphics/bone.h"
 
-#include <Ogre.h>
+#include <OgreBone.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/cameraproxy.cpp
+++ b/Mezzanine/src/Graphics/cameraproxy.cpp
@@ -51,7 +51,9 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreCamera.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/d3d11rendersyshelper.cpp
+++ b/Mezzanine/src/Graphics/d3d11rendersyshelper.cpp
@@ -44,9 +44,8 @@
 
 #include "exception.h"
 
-#include <Ogre.h>
-
-#include "OgreD3D11Plugin.h"
+#include <OgreRoot.h>
+#include <OgreD3D11Plugin.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/d3d9rendersyshelper.cpp
+++ b/Mezzanine/src/Graphics/d3d9rendersyshelper.cpp
@@ -44,9 +44,8 @@
 
 #include "exception.h"
 
-#include <Ogre.h>
-
-#include "OgreD3D9Plugin.h"
+#include <OgreRoot.h>
+#include <OgreD3D9Plugin.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/entityproxy.cpp
+++ b/Mezzanine/src/Graphics/entityproxy.cpp
@@ -53,7 +53,9 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreEntity.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/gamewindow.cpp
+++ b/Mezzanine/src/Graphics/gamewindow.cpp
@@ -66,7 +66,9 @@
 
 #include <SDL.h>
 #include "../src/video/SDL_sysvideo.h"
-#include <Ogre.h>
+
+#include <OgreRoot.h>
+#include <OgreRenderWindow.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/graphicsmanager.cpp
+++ b/Mezzanine/src/Graphics/graphicsmanager.cpp
@@ -55,7 +55,12 @@
 #include "entresol.h"
 
 #include <SDL.h>
-#include <Ogre.h>
+
+#include <OgreRoot.h>
+#include <OgreRenderSystem.h>
+#include <OgreRenderSystemCapabilities.h>
+#include <OgreRenderWindow.h>
+#include <OgreWindowEventUtilities.h>
 
 #ifdef MEZZ_BUILD_DIRECTX9_SUPPORT
 #include "d3d9rendersyshelper.h.cpp"

--- a/Mezzanine/src/Graphics/image.cpp
+++ b/Mezzanine/src/Graphics/image.cpp
@@ -49,7 +49,10 @@
 
 #include "Internal/iostreamwrapper.h.cpp"
 
-#include <Ogre.h>
+#include <OgreColourValue.h>
+#include <OgreImage.h>
+#include <OgreTexture.h>
+#include <OgreHardwarePixelBuffer.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/lightproxy.cpp
+++ b/Mezzanine/src/Graphics/lightproxy.cpp
@@ -50,7 +50,9 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreLight.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/linegroupproxy.cpp
+++ b/Mezzanine/src/Graphics/linegroupproxy.cpp
@@ -43,7 +43,12 @@
 #include "linegroupproxy.h"
 #include "Graphics/scenemanager.h"
 
-#include <Ogre.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreCamera.h>
+#include <OgreSimpleRenderable.h>
+#include <OgreHardwareBufferManager.h>
+
 #include <vector>
 
 namespace Mezzanine

--- a/Mezzanine/src/Graphics/material.cpp
+++ b/Mezzanine/src/Graphics/material.cpp
@@ -42,7 +42,8 @@
 #define _graphicsmaterial_cpp
 
 #include "Graphics/material.h"
-#include <Ogre.h>
+
+#include <OgreMaterial.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/mesh.cpp
+++ b/Mezzanine/src/Graphics/mesh.cpp
@@ -43,7 +43,7 @@
 #include "Graphics/mesh.h"
 #include "Graphics/submesh.h"
 
-#include <Ogre.h>
+#include <OgreMesh.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/meshmanager.cpp
+++ b/Mezzanine/src/Graphics/meshmanager.cpp
@@ -48,7 +48,8 @@
 
 #include "Internal/iostreamwrapper.h.cpp"
 
-#include <Ogre.h>
+#include <OgreMeshManager.h>
+#include <OgreMeshSerializer.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/ogl3plusrendersyshelper.cpp
+++ b/Mezzanine/src/Graphics/ogl3plusrendersyshelper.cpp
@@ -44,9 +44,8 @@
 
 #include "exception.h"
 
-#include <Ogre.h>
-
-#include "OgreGL3PlusPlugin.h"
+#include <OgreRoot.h>
+#include <OgreGL3PlusPlugin.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/ogles2rendersyshelper.cpp
+++ b/Mezzanine/src/Graphics/ogles2rendersyshelper.cpp
@@ -44,9 +44,8 @@
 
 #include "exception.h"
 
-#include <Ogre.h>
-
-#include "OgreGLES2Plugin.h"
+#include <OgreRoot.h>
+#include <OgreGLES2Plugin.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/oglesrendersyshelper.cpp
+++ b/Mezzanine/src/Graphics/oglesrendersyshelper.cpp
@@ -44,9 +44,8 @@
 
 #include "exception.h"
 
-#include <Ogre.h>
-
-#include "OgreGLESPlugin.h"
+#include <OgreRoot.h>
+#include <OgreGLESPlugin.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/oglrendersyshelper.cpp
+++ b/Mezzanine/src/Graphics/oglrendersyshelper.cpp
@@ -44,9 +44,8 @@
 
 #include "exception.h"
 
-#include <Ogre.h>
-
-#include "OgreGLPlugin.h"
+#include <OgreRoot.h>
+#include <OgreGLPlugin.h>
 
 namespace
 {

--- a/Mezzanine/src/Graphics/particleaffector.cpp
+++ b/Mezzanine/src/Graphics/particleaffector.cpp
@@ -47,7 +47,7 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreParticleAffector.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/particleemitter.cpp
+++ b/Mezzanine/src/Graphics/particleemitter.cpp
@@ -47,7 +47,7 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreParticleEmitter.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/particlesystemproxy.cpp
+++ b/Mezzanine/src/Graphics/particlesystemproxy.cpp
@@ -52,7 +52,9 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreParticleSystem.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/pass.cpp
+++ b/Mezzanine/src/Graphics/pass.cpp
@@ -42,7 +42,8 @@
 #define _graphicspass_cpp
 
 #include "Graphics/pass.h"
-#include <Ogre.h>
+
+#include <OgrePass.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/renderableproxy.cpp
+++ b/Mezzanine/src/Graphics/renderableproxy.cpp
@@ -51,7 +51,9 @@
 #include "serialization.h"
 #include "stringtool.h"
 
-#include <Ogre.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreMovableObject.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/renderablerayquery.cpp
+++ b/Mezzanine/src/Graphics/renderablerayquery.cpp
@@ -56,7 +56,11 @@
 #include "world.h"
 #include "managerbase.h"
 
-#include <Ogre.h>
+#include <OgreSceneManager.h>
+#include <OgreEntity.h>
+#include <OgreParticleSystem.h>
+#include <OgreParticleSystemManager.h>
+#include <OgreBillboardSet.h>
 #include <OgreBillboardParticleRenderer.h>
 
 #include <limits>

--- a/Mezzanine/src/Graphics/scenemanager.cpp
+++ b/Mezzanine/src/Graphics/scenemanager.cpp
@@ -63,7 +63,8 @@
 
 #include <memory>
 
-#include <Ogre.h>
+#include <OgreRoot.h>
+#include <OgreSceneManager.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/skeleton.cpp
+++ b/Mezzanine/src/Graphics/skeleton.cpp
@@ -43,7 +43,7 @@
 #include "Graphics/skeleton.h"
 #include "Graphics/bone.h"
 
-#include <Ogre.h>
+#include <OgreSkeleton.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/submesh.cpp
+++ b/Mezzanine/src/Graphics/submesh.cpp
@@ -44,7 +44,11 @@
 #include "Graphics/submesh.h"
 #include "Graphics/vertextools.h"
 
-#include <Ogre.h>
+#include <OgreMesh.h>
+#include <OgreSubMesh.h>
+#include <OgreVertexIndexData.h>
+#include <OgreMaterialManager.h>
+#include <OgreMaterial.h>
 
 namespace Mezzanine
 {
@@ -110,7 +114,7 @@ namespace Mezzanine
             /// @todo Should probably be replaced with something that calls our material manager.
             Ogre::MaterialManager* MatMan = Ogre::MaterialManager::getSingletonPtr();
             if( !ToFill.MaterialName.empty() && MatMan != NULL ) {
-                Ogre::ResourcePtr Mat = MatMan->getByName( this->InternalSubMesh->getMaterialName() );
+                Ogre::MaterialPtr Mat = MatMan->getByName( this->InternalSubMesh->getMaterialName() );
                 ToFill.MaterialGroup = Mat->getOrigin();
             }
 

--- a/Mezzanine/src/Graphics/technique.cpp
+++ b/Mezzanine/src/Graphics/technique.cpp
@@ -42,7 +42,8 @@
 #define _graphicstechnique_cpp
 
 #include "Graphics/technique.h"
-#include <Ogre.h>
+
+#include <OgreTechnique.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/texture.cpp
+++ b/Mezzanine/src/Graphics/texture.cpp
@@ -45,8 +45,9 @@
 
 #include "exception.h"
 
-#include <Ogre.h>
+#include <OgreTexture.h>
 #include <OgrePixelFormat.h>
+#include <OgreHardwarePixelBuffer.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/texturemanager.cpp
+++ b/Mezzanine/src/Graphics/texturemanager.cpp
@@ -43,7 +43,7 @@
 #include "Graphics/texturemanager.h"
 #include "Graphics/texture.h"
 
-#include <Ogre.h>
+#include <OgreTextureManager.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/texturepacker.cpp
+++ b/Mezzanine/src/Graphics/texturepacker.cpp
@@ -46,7 +46,7 @@
 #include "Graphics/texture.h"
 #include "Graphics/texturemanager.h"
 
-#include <Ogre.h>
+#include <OgrePixelFormat.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/vertextools.cpp
+++ b/Mezzanine/src/Graphics/vertextools.cpp
@@ -42,7 +42,7 @@
 
 #include "Graphics/vertextools.h"
 
-#include <Ogre.h>
+#include <OgreVertexIndexData.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Graphics/viewport.cpp
+++ b/Mezzanine/src/Graphics/viewport.cpp
@@ -47,7 +47,8 @@
 #include "serialization.h"
 #include "exception.h"
 
-#include <Ogre.h>
+#include <OgreViewport.h>
+#include <OgreRenderWindow.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Internal/meshloaderlistener.cpp
+++ b/Mezzanine/src/Internal/meshloaderlistener.cpp
@@ -48,6 +48,11 @@
 
 #include "Resource/resourcemanager.h"
 
+#include <OgreMesh.h>
+#include <OgreSkeleton.h>
+#include <OgreSkeletonManager.h>
+#include <OgreSkeletonSerializer.h>
+
 namespace Mezzanine
 {
     namespace Internal

--- a/Mezzanine/src/Internal/meshloaderlistener.h.cpp
+++ b/Mezzanine/src/Internal/meshloaderlistener.h.cpp
@@ -43,8 +43,11 @@
 // Keeps this file form being documented by doxygen
 /// @cond DontDocumentInternal
 
-#include <Ogre.h>
 #include "datatypes.h"
+
+#include <OgreDataStream.h>
+#include <OgreIteratorWrapper.h>
+#include <OgreMeshSerializer.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Physics/collisionshapemanager.cpp
+++ b/Mezzanine/src/Physics/collisionshapemanager.cpp
@@ -66,7 +66,12 @@
 #include "stringtool.h"
 #include "entresol.h"
 
-#include <Ogre.h>
+#include <OgreMesh.h>
+#include <OgreSubMesh.h>
+#include <OgreHardwareBufferManager.h>
+#include <OgreHardwareVertexBuffer.h>
+#include <OgreHardwareIndexBuffer.h>
+
 #include "btBulletDynamicsCommon.h"
 #include "BulletSoftBody/btSoftRigidDynamicsWorld.h"
 #include "BulletCollision/CollisionShapes/btShapeHull.h"

--- a/Mezzanine/src/Resource/assetgroup.cpp
+++ b/Mezzanine/src/Resource/assetgroup.cpp
@@ -44,7 +44,8 @@
 #include "memorystream.h"
 #include "filestream.h"
 
-#include <Ogre.h>
+#include <OgreResourceGroupManager.h>
+#include <OgreDataStream.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/Resource/resourcemanager.cpp
+++ b/Mezzanine/src/Resource/resourcemanager.cpp
@@ -55,7 +55,9 @@
 #include <fstream>
 #include <cstdlib>
 
-#include <Ogre.h>
+#include <OgreResourceGroupManager.h>
+#include <OgreDataStream.h>
+#include <OgreArchive.h>
 //#include <btBulletWorldImporter.h>
 //#include <btBulletDynamicsCommon.h>
 

--- a/Mezzanine/src/axisalignedbox.cpp
+++ b/Mezzanine/src/axisalignedbox.cpp
@@ -51,7 +51,7 @@
 #include "exception.h"
 #include "serialization.h"
 
-#include <Ogre.h>
+#include <OgreAxisAlignedBox.h>
 
 #include <algorithm>
 

--- a/Mezzanine/src/colourvalue.cpp
+++ b/Mezzanine/src/colourvalue.cpp
@@ -45,9 +45,10 @@
 #include "serialization.h"
 #include "exception.h"
 
-#include <Ogre.h>
+#include <OgreColourValue.h>
 
 #include <memory>
+
 namespace Mezzanine
 {
     ColourValue::ColourValue(Real Red, Real Green, Real Blue, Real Alpha)

--- a/Mezzanine/src/entresol.cpp
+++ b/Mezzanine/src/entresol.cpp
@@ -82,23 +82,17 @@
     #include "Scripting/Lua51/lua51scriptingengine.h"
 #endif // MEZZLUA51
 
-
-//#include "OgreBspSceneManagerPlugin.h"
-//#include "OgreCgPlugin.h"
-//#include "OgreOctreePlugin.h"
-//#include "OgreOctreeZonePlugin.h"
-#include "OgreParticleFXPlugin.h"
-//#include "OgrePCZPlugin.h"
+#include <OgreParticleFXPlugin.h>
 
 #include <SDL.h>
-#include <Ogre.h>
-#include <btBulletDynamicsCommon.h>
+
+#include <OgreRoot.h>
+#include <OgreLogManager.h>
+#include <OgreParticleFXPlugin.h>
 
 #include <sstream>
 #include <string>
 #include <cassert>
-
-using namespace std;
 
 namespace Mezzanine
 {
@@ -531,7 +525,7 @@ namespace Mezzanine
         for( ManagerIterator Iter = this->ManagerList.begin() ; Iter != this->ManagerList.end() ; ++Iter )
         {
             StringStream InitStream;
-            InitStream << "Initializing " << (*Iter)->GetImplementationTypeName() << " as " << (*Iter)->GetInterfaceTypeAsString() << "." << endl;
+            InitStream << "Initializing " << (*Iter)->GetImplementationTypeName() << " as " << (*Iter)->GetInterfaceTypeAsString() << "." << std::endl;
             this->_Log( InitStream.str() );
             if( (*Iter)->GetInterfaceType() != ManagerBase::MT_GraphicsManager ) {
                 (*Iter)->Initialize();
@@ -557,7 +551,7 @@ namespace Mezzanine
         for( ManagerIterator Iter = this->ManagerList.begin() ; Iter != this->ManagerList.end() ; ++Iter )
         {
             StringStream DeinitStream;
-            DeinitStream << "Deinitializing " << (*Iter)->GetImplementationTypeName() << " as " << (*Iter)->GetInterfaceTypeAsString() << "." << endl;
+            DeinitStream << "Deinitializing " << (*Iter)->GetImplementationTypeName() << " as " << (*Iter)->GetInterfaceTypeAsString() << "." << std::endl;
             this->_Log( DeinitStream.str() );
             (*Iter)->Deinitialize();
         }
@@ -587,7 +581,7 @@ namespace Mezzanine
     void Entresol::DoOneFrame()
     {
         #ifdef MEZZDEBUG
-        WorkScheduler.GetLog() << "<FrameCounterStart Frame=\"" << WorkScheduler.GetFrameCount() << "\" Time=\"" << GetTimeStamp()<< "\" />" << endl;
+        WorkScheduler.GetLog() << "<FrameCounterStart Frame=\"" << WorkScheduler.GetFrameCount() << "\" Time=\"" << GetTimeStamp()<< "\" />" << std::endl;
         #endif
         WorkScheduler.RunAllMonopolies(); //1
         WorkScheduler.CreateThreads();    //2
@@ -595,11 +589,11 @@ namespace Mezzanine
         WorkScheduler.JoinAllThreads();   //4
         WorkScheduler.ResetAllWorkUnits();//5
         #ifdef MEZZDEBUG
-        WorkScheduler.GetLog() << "<FrameCounterPrePause Frame=\"" << WorkScheduler.GetFrameCount() << "\" Time=\"" << GetTimeStamp()<< "\" />" << endl;
+        WorkScheduler.GetLog() << "<FrameCounterPrePause Frame=\"" << WorkScheduler.GetFrameCount() << "\" Time=\"" << GetTimeStamp()<< "\" />" << std::endl;
         #endif
         WorkScheduler.WaitUntilNextFrame(); //6
         #ifdef MEZZDEBUG
-        WorkScheduler.GetLog() << "<FrameCounterEnd Frame=\"" << WorkScheduler.GetFrameCount() << "\" Time=\"" << GetTimeStamp()<< "\" />" << endl;
+        WorkScheduler.GetLog() << "<FrameCounterEnd Frame=\"" << WorkScheduler.GetFrameCount() << "\" Time=\"" << GetTimeStamp()<< "\" />" << std::endl;
         #endif
     }
 

--- a/Mezzanine/src/entresol.h
+++ b/Mezzanine/src/entresol.h
@@ -286,10 +286,10 @@
 #endif
 
 //Other forward declarations
-//forward Declarations so that we do not need #include "SDL.h"
+//forward Declarations for SDL
 class SDL_Surface;
 
-//forward Declarations so that we do not need #include <Ogre.h>
+//forward Declarations for Ogre
 namespace Ogre
 {
     class ParticleFXPlugin;

--- a/Mezzanine/src/quaternion.cpp
+++ b/Mezzanine/src/quaternion.cpp
@@ -48,7 +48,7 @@
 #include "matrix3x3.h"
 #include "exception.h"
 
-#include <Ogre.h>
+#include <OgreQuaternion.h>
 #include "btBulletDynamicsCommon.h"
 
 #include <cmath>

--- a/Mezzanine/src/ray.cpp
+++ b/Mezzanine/src/ray.cpp
@@ -49,7 +49,7 @@
 #include "exception.h"
 #include "serialization.h"
 
-#include <Ogre.h>
+#include <OgreRay.h>
 
 #include <ostream>
 

--- a/Mezzanine/src/sphere.cpp
+++ b/Mezzanine/src/sphere.cpp
@@ -52,7 +52,7 @@
 #include "exception.h"
 #include "serialization.h"
 
-#include <Ogre.h>
+#include <OgreSphere.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/vector2.cpp
+++ b/Mezzanine/src/vector2.cpp
@@ -48,7 +48,7 @@
 
 //#include <memory>
 
-#include <Ogre.h>
+#include <OgreVector2.h>
 
 namespace Mezzanine
 {

--- a/Mezzanine/src/vector3.cpp
+++ b/Mezzanine/src/vector3.cpp
@@ -46,12 +46,9 @@
 #include "serialization.h"
 #include "stringtool.h"
 #include "MathTools/mathtools.h"
-#ifndef SWIG
-    #include "XML/xml.h"
-#endif
 #include "XML/xml.h"            // Needed for streaming to xml
 
-#include <Ogre.h>
+#include <OgreVector3.h>
 #include "btBulletDynamicsCommon.h"
 
 #include <memory>


### PR DESCRIPTION
Changed almost all instances of #include <Ogre.h> to actual headers needed.  Ogre still has a ton of header pollution, but this is the most we can do atm.  It has helped cut down on the number of reported warnings.