### PR TITLE
Proposed-LeanerEvents

### DIFF
--- a/Mezzanine/src/eventpublisher.cpp
+++ b/Mezzanine/src/eventpublisher.cpp
@@ -77,107 +77,116 @@ namespace Mezzanine
     ///////////////////////////////////////////////////////////////////////////////
     // Subscription Table Management
 
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // Subscription Table Management - Via Name
+
     EventPublisher::SubscriptionTableIterator EventPublisher::AddSubscriptionTable(const EventNameType& EventName)
+        { return this->AddSubscriptionTable(EventName.GetHash()); }
+
+    Boole EventPublisher::HasSubscriptionTable(const EventNameType& EventName) const
+        { return this->HasSubscriptionTable(EventName.GetHash()); }
+
+    EventPublisher::SubscriptionTableIterator EventPublisher::GetSubscriptionTable(const EventNameType& EventName)
+        { return this->GetSubscriptionTable(EventName.GetHash()); }
+
+    EventPublisher::ConstSubscriptionTableIterator EventPublisher::GetSubscriptionTable(const EventNameType& EventName) const
+        { return this->GetSubscriptionTable(EventName.GetHash()); }
+
+    void EventPublisher::RemoveSubscriptionTable(const EventNameType& EventName)
+        { this->RemoveSubscriptionTable(EventName.GetHash()); }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // Subscription Table Management - Via Hash
+
+    EventPublisher::SubscriptionTableIterator EventPublisher::AddSubscriptionTable(const EventHashType EventHash)
     {
-        SubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventName);
+        SubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventHash);
         if( TableIt == this->SubscriptionTables.end() ) {
-            return this->SubscriptionTables.add_emplace([](const EventSubscriptionTable& EvTable, const EventNameType& EventName) {
-                return EvTable.GetName() < EventName;
-            }, EventName);
+            return this->SubscriptionTables.add_emplace([](const EventSubscriptionTable& EvTable, EventHashType EventHash) {
+                return EvTable.GetHash() < EventHash;
+            }, EventHash);
         }else{
-            MEZZ_EXCEPTION(ExceptionBase::II_DUPLICATE_IDENTITY_EXCEPTION,"An EventSubscriptionTable with the name \"" + EventName + "\" already exists!");
+            StringStream ExceptionStream;
+            ExceptionStream << "An EventSubscriptionTable with the hash \"" <<  EventHash << "\" already exists!" << std::endl;
+            MEZZ_EXCEPTION(ExceptionBase::II_DUPLICATE_IDENTITY_EXCEPTION,ExceptionStream.str());
         }
     }
 
-    Boole EventPublisher::HasSubscriptionTable(const EventNameType& EventName) const
+    Boole EventPublisher::HasSubscriptionTable(const EventHashType EventHash) const
     {
-        ConstSubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventName);
+        ConstSubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventHash);
         return TableIt != this->SubscriptionTables.end();
     }
 
-    Boole EventPublisher::HasSubscriptionTable(const Int32 EventHash) const
+    EventPublisher::SubscriptionTableIterator EventPublisher::GetSubscriptionTable(const EventHashType EventHash)
     {
-        for( const EventSubscriptionTable& CurrTable : this->SubscriptionTables )
-        {
-            if( CurrTable.GetName().GetHash() == EventHash ) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    EventPublisher::SubscriptionTableIterator EventPublisher::GetSubscriptionTable(const EventNameType& EventName)
-    {
-        SubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventName);
+        SubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventHash);
         if( TableIt != this->SubscriptionTables.end() ) {
             return TableIt;
         }else{
-            MEZZ_EXCEPTION(ExceptionBase::II_IDENTITY_NOT_FOUND_EXCEPTION,"Event name \"" + EventName + "\" not found in publisher.");
+            StringStream ExceptionStream;
+            ExceptionStream << "Event hash \"" << EventHash << "\" not found in publisher." << std::endl;
+            MEZZ_EXCEPTION(ExceptionBase::II_IDENTITY_NOT_FOUND_EXCEPTION,ExceptionStream.str());
         }
         return this->SubscriptionTables.end();
     }
 
-    EventPublisher::SubscriptionTableIterator EventPublisher::GetSubscriptionTable(const Int32 EventHash)
+    EventPublisher::ConstSubscriptionTableIterator EventPublisher::GetSubscriptionTable(const EventHashType EventHash) const
     {
-        for( SubscriptionTableIterator TableIt = this->SubscriptionTables.begin() ; TableIt != this->SubscriptionTables.end() ; ++TableIt )
-        {
-            if( (*TableIt).GetName().GetHash() == EventHash ) {
-                return TableIt;
-            }
-        }
-        StringStream ExceptionStream;
-        ExceptionStream << "Event hash \"" << EventHash << "\" not found in publisher.";
-        MEZZ_EXCEPTION(ExceptionBase::II_IDENTITY_NOT_FOUND_EXCEPTION,ExceptionStream.str());
-    }
-
-    EventPublisher::ConstSubscriptionTableIterator EventPublisher::GetSubscriptionTable(const EventNameType& EventName) const
-    {
-        ConstSubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventName);
+        ConstSubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventHash);
         if( TableIt != this->SubscriptionTables.end() ) {
             return TableIt;
         }else{
-            MEZZ_EXCEPTION(ExceptionBase::II_IDENTITY_NOT_FOUND_EXCEPTION,"Event name \"" + EventName + "\" not found in publisher.");
+            StringStream ExceptionStream;
+            ExceptionStream << "Event hash \"" << EventHash << "\" not found in publisher." << std::endl;
+            MEZZ_EXCEPTION(ExceptionBase::II_IDENTITY_NOT_FOUND_EXCEPTION,ExceptionStream.str());
         }
         return this->SubscriptionTables.end();
     }
 
-    EventPublisher::ConstSubscriptionTableIterator EventPublisher::GetSubscriptionTable(const Int32 EventHash) const
+    void EventPublisher::RemoveSubscriptionTable(const EventHashType EventHash)
     {
-        for( ConstSubscriptionTableIterator TableIt = this->SubscriptionTables.begin() ; TableIt != this->SubscriptionTables.end() ; ++TableIt )
-        {
-            if( (*TableIt).GetName().GetHash() == EventHash ) {
-                return TableIt;
-            }
-        }
-        StringStream ExceptionStream;
-        ExceptionStream << "Event hash \"" << EventHash << "\" not found in publisher.";
-        MEZZ_EXCEPTION(ExceptionBase::II_IDENTITY_NOT_FOUND_EXCEPTION,ExceptionStream.str());
-    }
-
-    void EventPublisher::RemoveSubscriptionTable(const EventNameType& EventName)
-    {
-        SubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventName);
+        SubscriptionTableIterator TableIt = this->SubscriptionTables.find(EventHash);
         if( TableIt != this->SubscriptionTables.end() ) {
             this->SubscriptionTables.erase(TableIt);
         }
     }
 
+    ///////////////////////////////////////////////////////////////////////////////
+    // Subscription Table Management
+
     void EventPublisher::RemoveAllSubscriptionTables()
         { this->SubscriptionTables.clear(); }
 
     ///////////////////////////////////////////////////////////////////////////////
-    // Subscription Management
+    // Subscription Management - Via Name
 
-    EventSubscriberBindingPtr EventPublisher::Subscribe(const EventNameType& EventName, EventSubscriberID ID, const CallbackType& Delegate)
-        { return this->GetSubscriptionTable(EventName)->Subscribe(ID,Delegate,this); }
+    EventSubscriberBindingPtr EventPublisher::Subscribe(const EventNameType& EventName, const EventSubscriberID ID, const CallbackType& Delegate)
+        { return this->Subscribe(EventName.GetHash(),ID,Delegate); }
 
-    void EventPublisher::Unsubscribe(const EventNameType& EventName, EventSubscriberID ID)
-        { this->GetSubscriptionTable(EventName)->Unsubscribe(ID); }
+    void EventPublisher::Unsubscribe(const EventNameType& EventName, const EventSubscriberID ID)
+        { this->Unsubscribe(EventName.GetHash(),ID); }
 
     Whole EventPublisher::UnsubscribeAll(const EventNameType& EventName)
-        { return this->GetSubscriptionTable(EventName)->UnsubscribeAll(); }
+        { return this->UnsubscribeAll(EventName.GetHash()); }
 
-    void EventPublisher::Unsubscribe(EventSubscriberID ID)
+    ///////////////////////////////////////////////////////////////////////////////
+    // Subscription Management - Via Hash
+
+    EventSubscriberBindingPtr EventPublisher::Subscribe(const EventHashType EventHash, const EventSubscriberID ID, const CallbackType& Delegate)
+        { return this->GetSubscriptionTable(EventHash)->Subscribe(ID,Delegate,this); }
+
+    void EventPublisher::Unsubscribe(const EventHashType EventHash, const EventSubscriberID ID)
+        { this->GetSubscriptionTable(EventHash)->Unsubscribe(ID); }
+
+    Whole EventPublisher::UnsubscribeAll(const EventHashType EventHash)
+        { return this->GetSubscriptionTable(EventHash)->UnsubscribeAll(); }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // Subscription Management
+
+    void EventPublisher::Unsubscribe(const EventSubscriberID ID)
     {
         for( EventSubscriptionTable& CurrTable : this->SubscriptionTables )
             { CurrTable.Unsubscribe(ID); }

--- a/Mezzanine/src/eventpublisher.h
+++ b/Mezzanine/src/eventpublisher.h
@@ -206,10 +206,10 @@ namespace Mezzanine
         void DispatchEvent(EventPtr Args) const;
 
         ///////////////////////////////////////////////////////////////////////////////
-        // Subscription Table Management
+        // Subscription Table Management - Via Name
 
         /// @brief Creates a new event table representing an event that can be subscribed to.
-        /// @exception If a subscription table with that name already exists it will throw a "II_DUPLICATE_IDENTITY_EXCEPTION".
+        /// @exception If a subscription table with the names hash already exists it will throw a "II_DUPLICATE_IDENTITY_EXCEPTION".
         /// @param EventName The name to be given to the new event subscription table.
         /// @return Returns an iterator to the created event table.
         SubscriptionTableIterator AddSubscriptionTable(const EventNameType& EventName);
@@ -217,43 +217,57 @@ namespace Mezzanine
         /// @param EventName The name of the table to check for.
         /// @return Returns true of the named event table is present in this publisher.
         Boole HasSubscriptionTable(const EventNameType& EventName) const;
-        /// @brief Checks to see if an event table is registered with and has a subscriber table in this publisher.
-        /// @remarks The EventNameType overload of this method should be used instead where possible.
-        /// @param EventHash The generated hash for the table name to check for.
-        /// @return Returns true of the named event table is present in this publisher.
-        Boole HasSubscriptionTable(const Int32 EventHash) const;
-
         /// @brief Gets an event table in this publisher.
         /// @exception If this fails to find the table specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
         /// @param EventName The name of the table to retrieve.
         /// @return Returns an iterator to the requested event table or throws an exception if it was not found.
         SubscriptionTableIterator GetSubscriptionTable(const EventNameType& EventName);
         /// @brief Gets an event table in this publisher.
-        /// @remarks The EventNameType overload of this method should be used instead where possible.
-        /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
-        /// @param EventHash The generated hash for the event name to retrieve.
-        /// @return Returns an iterator to the requested event table or throws an exception if it was not found.
-        SubscriptionTableIterator GetSubscriptionTable(const Int32 EventHash);
-        /// @brief Gets an event table in this publisher.
         /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
         /// @param EventName The name of the event to retrieve.
         /// @return Returns a const iterator to the requested event table or throws an exception if it was not found.
         ConstSubscriptionTableIterator GetSubscriptionTable(const EventNameType& EventName) const;
+        /// @brief Removes an existing event in this Publisher.
+        /// @param EventName The name of the event to be removed.
+        void RemoveSubscriptionTable(const EventNameType& EventName);
+
+        ///////////////////////////////////////////////////////////////////////////////
+        // Subscription Table Management - Via Hash
+
+        /// @brief Creates a new event table representing an event that can be subscribed to.
+        /// @exception If a subscription table with the names hash already exists it will throw a "II_DUPLICATE_IDENTITY_EXCEPTION".
+        /// @param EventName The generated hash to use to identify the new event subscription table.
+        /// @return Returns an iterator to the created event table.
+        SubscriptionTableIterator AddSubscriptionTable(const EventHashType EventHash);
+        /// @brief Checks to see if an event table is registered with and has a subscriber table in this publisher.
+        /// @remarks The EventNameType overload of this method should be used instead where possible.
+        /// @param EventHash The generated hash for the table name to check for.
+        /// @return Returns true of the named event table is present in this publisher.
+        Boole HasSubscriptionTable(const EventHashType EventHash) const;
+        /// @brief Gets an event table in this publisher.
+        /// @remarks The EventNameType overload of this method should be used instead where possible.
+        /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
+        /// @param EventHash The generated hash for the event name to retrieve.
+        /// @return Returns an iterator to the requested event table or throws an exception if it was not found.
+        SubscriptionTableIterator GetSubscriptionTable(const EventHashType EventHash);
         /// @brief Gets an event table in this publisher.
         /// @remarks The EventNameType overload of this method should be used instead where possible.
         /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
         /// @param EventHash The generated hash for the event name to retrieve.
         /// @return Returns a const iterator to the requested event table or throws an exception if it was not found.
-        ConstSubscriptionTableIterator GetSubscriptionTable(const Int32 EventHash) const;
-
+        ConstSubscriptionTableIterator GetSubscriptionTable(const EventHashType EventHash) const;
         /// @brief Removes an existing event in this Publisher.
-        /// @param EventName The name of the event to be removed.
-        void RemoveSubscriptionTable(const EventNameType& EventName);
+        /// @param EventHash The generated hash for the event name to remove.
+        void RemoveSubscriptionTable(const EventHashType EventHash);
+
+        ///////////////////////////////////////////////////////////////////////////////
+        // Subscription Table Management
+
         /// @brief Removes all events in this Publisher.
         void RemoveAllSubscriptionTables();
 
         ///////////////////////////////////////////////////////////////////////////////
-        // Subscription Management
+        // Subscription Management - Via Name
 
         /// @brief Adds a subscriber to this event.
         /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
@@ -261,22 +275,45 @@ namespace Mezzanine
         /// @param ID The unique ID of the subscriber.  Must be unique among the IDs of this publisher.
         /// @param Delegate The callback to be called when the interested event is fired.
         /// @return Returns a pointer to the created Subscriber slot for the provided subscriber.
-        EventSubscriberBindingPtr Subscribe(const EventNameType& EventName, EventSubscriberID ID, const CallbackType& Delegate);
-
+        EventSubscriberBindingPtr Subscribe(const EventNameType& EventName, const EventSubscriberID ID, const CallbackType& Delegate);
         /// @brief Removes a single subscriber from the named event.
         /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
         /// @param EventName The name of the event to unsubscribe from.
         /// @param ID The unique ID of the subscriber.  Must be unique among the IDs of this publisher.
-        void Unsubscribe(const EventNameType& EventName, EventSubscriberID ID);
+        void Unsubscribe(const EventNameType& EventName, const EventSubscriberID ID);
         /// @brief Removes all subscribers from the named Event.
         /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
         /// @param EventName The name of the event to unsubscribe from.
         /// @return Returns the number of subscribers removed.
         Whole UnsubscribeAll(const EventNameType& EventName);
 
+        ///////////////////////////////////////////////////////////////////////////////
+        // Subscription Management - Via Hash
+
+        /// @brief Adds a subscriber to this event.
+        /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
+        /// @param EventHash The generated hash identifying the event to subscribe to.
+        /// @param ID The unique ID of the subscriber.  Must be unique among the IDs of this publisher.
+        /// @param Delegate The callback to be called when the interested event is fired.
+        /// @return Returns a pointer to the created Subscriber slot for the provided subscriber.
+        EventSubscriberBindingPtr Subscribe(const EventHashType EventHash, const EventSubscriberID ID, const CallbackType& Delegate);
+        /// @brief Removes a single subscriber from the named event.
+        /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
+        /// @param EventHash The generated hash identifying the event to unsubscribe from.
+        /// @param ID The unique ID of the subscriber.  Must be unique among the IDs of this publisher.
+        void Unsubscribe(const EventHashType EventHash, const EventSubscriberID ID);
+        /// @brief Removes all subscribers from the named Event.
+        /// @exception If this fails to find the event specified it will throw a "II_IDENTITY_NOT_FOUND_EXCEPTION".
+        /// @param EventHash The generated hash identifying the event to unsubscribe from.
+        /// @return Returns the number of subscribers removed.
+        Whole UnsubscribeAll(const EventHashType EventHash);
+
+        ///////////////////////////////////////////////////////////////////////////////
+        // Subscription Management
+
         /// @brief Removes a single subscriber from all events in this publisher.
         /// @param ID The unique ID of the subscriber.  Must be unique among the IDs of this publisher.
-        void Unsubscribe(EventSubscriberID ID);
+        void Unsubscribe(const EventSubscriberID ID);
         /// @brief Removes all subscribers from all events in this publisher.
         /// @return Returns the number of subscribers removed.
         Whole UnsubscribeAll();

--- a/Mezzanine/src/eventsubscriptiontable.cpp
+++ b/Mezzanine/src/eventsubscriptiontable.cpp
@@ -47,8 +47,8 @@
 
 namespace Mezzanine
 {
-    EventSubscriptionTable::EventSubscriptionTable(const EventNameType& Name) :
-        EventName(Name)
+    EventSubscriptionTable::EventSubscriptionTable(const EventHashType Hash) :
+        EventHash(Hash)
         {  }
 
     EventSubscriptionTable::~EventSubscriptionTable()
@@ -58,13 +58,13 @@ namespace Mezzanine
     // Operators
 
     Boole EventSubscriptionTable::operator<(const EventSubscriptionTable& Other) const
-        { return this->EventName < Other.EventName; }
+        { return this->EventHash < Other.EventHash; }
 
     ///////////////////////////////////////////////////////////////////////////////
     // Utility
 
-    const EventNameType& EventSubscriptionTable::GetName() const
-        { return this->EventName; }
+    EventHashType EventSubscriptionTable::GetHash() const
+        { return this->EventHash; }
 
     ///////////////////////////////////////////////////////////////////////////////
     // Subscription Management
@@ -75,7 +75,7 @@ namespace Mezzanine
         if( NewBinding.use_count() > 0 /* != NULL */ ) {
             MEZZ_EXCEPTION(ExceptionBase::II_DUPLICATE_IDENTITY_EXCEPTION,"A subscriber with that ID already exists!");
         }
-        NewBinding = std::make_shared<EventSubscriberBinding>( ID,Delegate,Pub,this->EventName.GetHash() );
+        NewBinding = std::make_shared<EventSubscriberBinding>( ID,Delegate,Pub,this->EventHash );
         this->Bindings.push_back(NewBinding);
         return NewBinding;
     }

--- a/Mezzanine/src/eventsubscriptiontable.h
+++ b/Mezzanine/src/eventsubscriptiontable.h
@@ -65,8 +65,8 @@ namespace Mezzanine
     protected:
         /// @brief A container of all the subscriber bindings to this event table.
         BindingContainer Bindings;
-        /// @brief The name of the Event the subscribers in this table are subscribed to.
-        EventNameType EventName;
+        /// @brief The hash of the Event the subscribers in this table are subscribed to.
+        EventHashType EventHash;
     public:
         /// @brief Blank constructor.
         EventSubscriptionTable() = delete;
@@ -77,8 +77,8 @@ namespace Mezzanine
         /// @param Other The other table to be moved.
         EventSubscriptionTable(EventSubscriptionTable&& Other) = default;
         /// @brief Class constructor.
-        /// @param Name The name to be given to this event.
-        EventSubscriptionTable(const EventNameType& Name);
+        /// @param Hash The generated hash to use to identify this event.
+        EventSubscriptionTable(const EventHashType Hash);
         /// @brief Class destructor.
         ~EventSubscriptionTable();
 
@@ -102,9 +102,9 @@ namespace Mezzanine
         ///////////////////////////////////////////////////////////////////////////////
         // Utility
 
-        /// @brief Gets the name of the event associated with this table.
-        /// @return Returns a const reference of a hashed string containing the name of this event.
-        const EventNameType& GetName() const;
+        /// @brief Gets the hash of the event associated with this table.
+        /// @return Returns the hash identifying this event.
+        EventHashType GetHash() const;
 
         ///////////////////////////////////////////////////////////////////////////////
         // Subscription Management

--- a/UnitTests/tests/eventstests.h
+++ b/UnitTests/tests/eventstests.h
@@ -159,8 +159,8 @@ public:
             EventPublisher TestPublisher;
             TestPublisher.AddSubscriptionTable(TestName);
 
-            EventSubscriptionTable TestTable(TestName);
-            TEST(TestTable.GetName() == TestName,
+            EventSubscriptionTable TestTable(TestName.GetHash());
+            TEST(TestTable.GetHash() == TestName.GetHash(),
                  "EventSubscriptionTable::ConstructionAndGetters");
 
             EventSubscriberBindingPtr FirstBinding = TestTable.Subscribe(16,TestCallback,&TestPublisher);
@@ -211,11 +211,11 @@ public:
             EventPublisher TestPublisher(2);
 
             EventPublisher::SubscriptionTableIterator TableIt = TestPublisher.AddSubscriptionTable(FirstTestName);
-            Boole FirstTestAdd = (*TableIt).GetName() == FirstTestName;
+            Boole FirstTestAdd = (*TableIt).GetHash() == FirstTestName.GetHash();
             TableIt = TestPublisher.AddSubscriptionTable(SecondTestName);
-            Boole SecondTestAdd = (*TableIt).GetName() == SecondTestName;
+            Boole SecondTestAdd = (*TableIt).GetHash() == SecondTestName.GetHash();
             TableIt = TestPublisher.AddSubscriptionTable(ThirdTestName);
-            Boole ThirdTestAdd = (*TableIt).GetName() == ThirdTestName;
+            Boole ThirdTestAdd = (*TableIt).GetHash() == ThirdTestName.GetHash();
             TEST(FirstTestAdd && SecondTestAdd && ThirdTestAdd,
                  "EventPublisher::ConstructionAndAddSubscriptionTable");
             TEST_THROW(ExceptionFactory<ExceptionBase::II_DUPLICATE_IDENTITY_EXCEPTION>::Type,
@@ -229,12 +229,12 @@ public:
                  "EventPublisher::HasSubscriptionTable");
 
             const EventPublisher& ConstTestPublisher = TestPublisher;
-            TEST(TestPublisher.GetSubscriptionTable(FirstTestName.GetHash())->GetName() == FirstTestName &&
-                 TestPublisher.GetSubscriptionTable(SecondTestName)->GetName() == SecondTestName &&
-                 TestPublisher.GetSubscriptionTable(ThirdTestName)->GetName() == ThirdTestName &&
-                 ConstTestPublisher.GetSubscriptionTable(FirstTestName.GetHash())->GetName() == FirstTestName &&
-                 ConstTestPublisher.GetSubscriptionTable(SecondTestName)->GetName() == SecondTestName &&
-                 ConstTestPublisher.GetSubscriptionTable(ThirdTestName)->GetName() == ThirdTestName,
+            TEST(TestPublisher.GetSubscriptionTable(FirstTestName.GetHash())->GetHash() == FirstTestName.GetHash() &&
+                 TestPublisher.GetSubscriptionTable(SecondTestName.GetHash())->GetHash() == SecondTestName.GetHash() &&
+                 TestPublisher.GetSubscriptionTable(ThirdTestName.GetHash())->GetHash() == ThirdTestName.GetHash() &&
+                 ConstTestPublisher.GetSubscriptionTable(FirstTestName.GetHash())->GetHash() == FirstTestName.GetHash() &&
+                 ConstTestPublisher.GetSubscriptionTable(SecondTestName.GetHash())->GetHash() == SecondTestName.GetHash() &&
+                 ConstTestPublisher.GetSubscriptionTable(ThirdTestName.GetHash())->GetHash() == ThirdTestName.GetHash(),
                  "EventPublisher::GetSubscriptionTable");
             TEST_THROW(ExceptionFactory<ExceptionBase::II_IDENTITY_NOT_FOUND_EXCEPTION>::Type,
                        TestPublisher.GetSubscriptionTable("FailFetch"),


### PR DESCRIPTION
EventSubscriptionTables have been updated to store the hash of the string identifying them exclusively, cutting the string portion out of what is being stored.  

This removes the memory footprint of using strings as well as the performance penalty when copying strings.